### PR TITLE
expand allowed file types in rcverify and fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Build Status](https://travis-ci.org/apache/openwhisk-release.svg?branch=master)](https://travis-ci.org/apache/openwhisk-release)
 
-This project provides the Apache OpenWhisk project's Release Managers with the instructions and automation needed to ensure project releases comply with both the Apache Software Foundation's (ASF) [Release Creation Process](http://www.apache.org/dev/release-publishing.html) and [Release Policy](http://www.apache.org/legal/release-policy.html).
+This project provides the Apache OpenWhisk project's Release Managers with the instructions and automation needed to ensure that project releases comply with both the Apache Software Foundation's (ASF) [Release Creation Process](http://www.apache.org/dev/release-publishing.html) and [Release Policy](http://www.apache.org/legal/release-policy.html).
 
 Specifically, this project documents the steps a Release Manager must take to make a release of an OpenWhisk software component and where possible provides scripts and tool support to reduce the number of manual steps and potential for human error during the process. Script support is provided for:
 - Packaging and signing source code (compressed archives)

--- a/docs/release_instructions.md
+++ b/docs/release_instructions.md
@@ -91,13 +91,13 @@ provide historical documentation of project releases.
     "openwhisk-repo-name-two"
   ],
   "openwhisk_repo_name_one": {
-    "name": "Apache OpenWhisk Repo Name",
+    "name": "OpenWhisk Repo Name",
     "hash": "<GIT COMMIT HASH>",
     "repository": "https://github.com/apache/openwhisk-<REPO-NAME-ONE>.git",
     "branch": "master"
   },
   "openwhisk_repo_name_two": {
-    "name": "Apache OpenWhisk Repo Two",
+    "name": "OpenWhisk Repo Two",
     "hash": "<GIT COMMIT HASH>",
     "repository": "https://github.com/apache/openwhisk-<REPO-NAME-TWO>.git",
     "branch": "master"

--- a/tools/config_template.json
+++ b/tools/config_template.json
@@ -8,15 +8,15 @@
     "openwhisk-repo-name-two"
   ],
   "openwhisk_repo_name_one": {
-    "name": "Apache OpenWhisk Repo Name",
+    "name": "OpenWhisk Project One",
     "hash": "<GIT COMMIT HASH>",
-    "repository": "https://github.com/apache/openwhisk-<REPO-NAME-TWO>.git",
+    "repository": "https://github.com/apache/openwhisk-<REPO-NAME-ONE>.git",
     "branch": "master"
   },
   "openwhisk_repo_name_two": {
-    "name": "Apache OpenWhisk Repo Two",
+    "name": "OpenWhisk Project Two",
     "hash": "<GIT COMMIT HASH>",
-    "repository": "https://github.com/apache/openwhisk-<REPO-NAME-ONE>.git",
+    "repository": "https://github.com/apache/openwhisk-<REPO-NAME-TWO>.git",
     "branch": "master"
   }
 }

--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -171,11 +171,11 @@ SC=$(eval $CMD >& /dev/null)
 validate $? 0 "$CMD"
 
 printf "scanning for executable files..."
-EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -name "*.php" ! -name "gradlew" ! -name "gradlew.bat" ! -path "*/bin/*" -perm -001)
+EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -name "*.php" ! -name "gradlew" ! -name "gradlew.bat" ! -name "exec" ! -path "*/bin/*" -perm -001)
 validate "$EXE" "" "$EXE"
 
-printf "scanning for non-text files..."
-EXE=$(find "$DIR/$BASE" -type f -exec file --mime {} \; | grep -v ": text/")
+printf "scanning for unexpected file types..."
+EXE=$(find "$DIR/$BASE" -type f -exec file --mime {} \; | grep -v ": text/" | grep -v ": inode/x-empty" | grep -v ": image/")
 validate "$EXE" "" "$EXE"
 
 printf "scanning for archives..."


### PR DESCRIPTION
rcverify file-type expansions:
  1. We should allow empty files (for example json files produced by i8n tooling) in releases.
  2. Allow png files in releases because they are included in html documentation.

Also fix a few typos.
