### PR TITLE
exclude empty files in the find command; not by mime type

### DIFF
--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -175,7 +175,7 @@ EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -
 validate "$EXE" "" "$EXE"
 
 printf "scanning for unexpected file types..."
-EXE=$(find "$DIR/$BASE" -type f -exec file --mime {} \; | grep -v ": text/" | grep -v ": inode/x-empty" | grep -v ": image/")
+EXE=$(find "$DIR/$BASE" -type f -and -not -empty -exec file --mime {} \; | grep -v ": text/" | grep -v ": image/")
 validate "$EXE" "" "$EXE"
 
 printf "scanning for archives..."


### PR DESCRIPTION
Apparently the mime type reported by file of a zero byte file
is platform dependent; so it is better to use a smarter find
command than to filter out later...