### PR TITLE
Improve file matching when there are multiple release candidates 

### DIFF
--- a/tools/upload_to_dist.sh
+++ b/tools/upload_to_dist.sh
@@ -31,7 +31,8 @@ svn update
 
 cd "$RELEASE_SVN_DIR"
 
-for artifact in `ls "$STAGE_SVN_DIR/$pre_release_version"`; do
+for artifact in `find "$STAGE_SVN_DIR/$pre_release_version" -name "*${version}*"`; do
+    artifact=$(basename -- "$artifact")
     cp "$STAGE_SVN_DIR/$pre_release_version/$artifact" $artifact
     svn add $artifact
 done


### PR DESCRIPTION
Where there are overlapping releases in staging, the `ls` is too ambiguous. This replaces `ls` no `find` and uses the `version` from the release config to further filter matching files.