### PR TITLE
nodejs 1.15.0 and pyton 1.14.0

### DIFF
--- a/release-configs/runtime-nodejs-1.15.0.config
+++ b/release-configs/runtime-nodejs-1.15.0.config
@@ -1,0 +1,15 @@
+{
+  "versioning": {
+    "version": "1.15.0",
+    "pre_release_version": "rc1"
+  },
+  "RepoList": [
+    "openwhisk-runtime-nodejs"
+  ],
+  "openwhisk_runtime_nodejs": {
+    "name": "OpenWhisk Runtime Node.js",
+    "hash": "7aca44335c567164a9108cf83c8c06b660f215a5",
+    "repository": "https://github.com/apache/openwhisk-runtime-nodejs.git",
+    "branch": "master"
+  }
+}

--- a/release-configs/runtime-python-1.14.0.config
+++ b/release-configs/runtime-python-1.14.0.config
@@ -1,0 +1,15 @@
+{
+  "versioning": {
+    "version": "1.14.0",
+    "pre_release_version": "rc1"
+  },
+  "RepoList": [
+    "openwhisk-runtime-python"
+  ],
+  "openwhisk_runtime_python": {
+    "name": "OpenWhisk Runtime Python",
+    "hash": "6e6db8b7c7cfe9273f54e0aa1e81d2c7c2214538",
+    "repository": "https://github.com/apache/openwhisk-runtime-python.git",
+    "branch": "master"
+  }
+}

--- a/tools/package_source_code.sh
+++ b/tools/package_source_code.sh
@@ -32,7 +32,7 @@ rm -rf $OPENWHISK_CLEANED_SOURCE_DIR/*
 # Clean up all the source code by excluding unnecessary files and folders
 # Remove hidden files and folder
 # Remove bin and build folders
-rsync -rtp --exclude gradle/wrapper/gradle-\*.jar --exclude .bin --exclude .jshintrc --exclude .pydevproject --exclude .rat-excludes --exclude .git\* --exclude .travis.yml --exclude credentials.json.enc --exclude build --exclude specification/archive --exclude specification/diagrams --exclude "*.odg" --exclude tests/src/integration $OPENWHISK_SOURCE_DIR/. $OPENWHISK_CLEANED_SOURCE_DIR
+rsync -rtp --exclude gradle/wrapper/gradle-\*.jar --exclude .bin --exclude .jshintrc --exclude .pydevproject --exclude .rat-excludes --exclude .git\* --exclude .travis.yml --exclude credentials.json.enc --exclude build --exclude specification/archive --exclude specification/diagrams --exclude "*.odg" --exclude docs/media --exclude tests/src/integration $OPENWHISK_SOURCE_DIR/. $OPENWHISK_CLEANED_SOURCE_DIR
 
 for repo in $(echo $repos | sed "s/,/ /g")
 do

--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -203,7 +203,7 @@ EXE=$(find "$DIR/$BASE" -type f -name "*.tar" -name "*.tgz" -o -name "*.gz" -o -
 validate "$EXE" "" "$EXE"
 
 printf "scanning for packages..."
-EXE=$(find "$DIR/$BASE" -type d -name "node_modules" -o -name ".gradle")
+EXE=$(find "$DIR/$BASE" -type d -name "node_modules" -o -name ".gradle" | grep -v tests/dat/actions/nodejs-test)
 validate "$EXE" "" "$EXE"
 
 printf "scanning package.json for version match..."


### PR DESCRIPTION
1. configs for rc1 of runtime-python 1.14.0 and runtime-nodejs 1.15.0
2. exclude pptx/pdf files in nodejs docs/media directory from release
3. tweak rcverify to allow node_modules directory inside tests/dat