### PR TITLE
exclude wskdebug.js from executable check to support openwhisk-wskdebug repo

### DIFF
--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -191,7 +191,7 @@ SC=$(eval $CMD >& /dev/null)
 validate $? 0 "$CMD"
 
 printf "scanning for executable files..."
-EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -name "*.php" ! -name "gradlew" ! -name "gradlew.bat" ! -name "exec" ! -name "wskadmin" ! -path "*/bin/*" -perm -001)
+EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -name "*.php" ! -name "gradlew" ! -name "gradlew.bat" ! -name "exec" ! -name "wskadmin" ! -name "wskdebug.js" ! -path "*/bin/*" -perm -001)
 validate "$EXE" "" "$EXE"
 
 printf "scanning for unexpected file types..."


### PR DESCRIPTION
Needed for https://github.com/apache/openwhisk-wskdebug/pull/2