### PR TITLE
Explicitly exclude JSON files.

### DIFF
--- a/tools/rcverify.sh
+++ b/tools/rcverify.sh
@@ -194,7 +194,7 @@ SC=$(eval $CMD >& /dev/null)
 validate $? 0 "$CMD"
 
 printf "scanning for executable files..."
-EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -name "*.php" ! -name "gradlew" ! -name "gradlew.bat" ! -name "exec" ! -name "wskadmin" ! -name "wskdebug.js" ! -path "*/bin/*" -perm -001)
+EXE=$(find "$DIR/$BASE" -type f ! -name "*.sh" ! -name "*.sh" ! -name "*.py" ! -name "*.php" ! -name "gradlew" ! -name "gradlew.bat" ! -name "exec" ! -name "wskadmin" ! -name "wskdebug.js" ! -name "*.json" ! -path "*/bin/*" -perm -001)
 validate "$EXE" "" "$EXE"
 
 printf "scanning for unexpected file types..."


### PR DESCRIPTION
It explicitly excludes JSON files from executable scanning.
This is because of the file below.
```
/OpenWhisk-1.0.0/ansible/files/whisks_design_document_for_activations_db_filters_v2.1.0.json
```

It is somehow not excluded while scanning.
