### PR TITLE
Add client-js-v3.21.4 rc config.

### DIFF
--- a/release-configs/client-js-3.21.4.config
+++ b/release-configs/client-js-3.21.4.config
@@ -1,6 +1,6 @@
 {
   "versioning": {
-    "version": "3.21.3",
+    "version": "3.21.4",
     "pre_release_version": "rc1"
   },
   "RepoList": [
@@ -8,7 +8,7 @@
   ],
   "openwhisk_client_js": {
     "name": "OpenWhisk Client Js",
-    "hash": "77f7c8fd2947517ea6e4d138c562179d13f549b2",
+    "hash": "c697f0be4a254a4d0ff8f98c4e746f479072fb7a",
     "repository": "https://github.com/apache/openwhisk-client-js.git",
     "branch": "master"
   }


### PR DESCRIPTION
This should not be merged until https://github.com/apache/openwhisk-client-js/pull/223 and https://github.com/apache/openwhisk-client-js/pull/224 are merged (so that the git hash can be confirmed).