### PR TITLE
client-js 1.21.7 release config

### DIFF
--- a/release-configs/client-js-3.21.7.config
+++ b/release-configs/client-js-3.21.7.config
@@ -1,0 +1,15 @@
+{
+  "versioning": {
+    "version": "3.21.7",
+    "pre_release_version": "rc1"
+  },
+  "RepoList": [
+    "openwhisk-client-js"
+  ],
+  "openwhisk_client_js": {
+    "name": "OpenWhisk Client Js",
+    "hash": "95f66ca1148ed489060627187e1ddbfb6052cfb5",
+    "repository": "https://github.com/apache/openwhisk-client-js.git",
+    "branch": "master"
+  }
+}


### PR DESCRIPTION
This release was made in August, but because the website publish was broken I hadn't submitted the config file or archived the prior version.