### PR TITLE
make scancode a mandatory check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,8 @@ github:
     master:
       required_status_checks:
         strict: false
+        contexts:
+           - "GitHub Actions - scancode"
       required_pull_request_reviews:
         required_appoving_review_count: 1
       required_signatures: false


### PR DESCRIPTION
Let's see if I understand the naming rules for GitHub actions in asf.yaml....